### PR TITLE
Import Flask helpers and add config

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, g
+from flask import Flask, render_template, request, g, make_response, redirect, url_for
 import os
 
 app = Flask(__name__)
@@ -11,6 +11,11 @@ def load_theme(theme_name='default'):
         'static': f'static/themes/{theme_name}',
         'template': f'themes/{theme_name}'
     }
+
+
+def get_recent_activities():
+    """Return a list of recent activities for the dashboard."""
+    return []
 
 # Tema seçimi middleware'i
 @app.before_request

--- a/config.py
+++ b/config.py
@@ -1,0 +1,2 @@
+DEBUG = True
+SECRET_KEY = 'your-secret-key'


### PR DESCRIPTION
## Summary
- import missing Flask helpers for response and routing
- define placeholder `get_recent_activities`
- add basic `config.py` for app configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689662b6779c8321add7024c8f30618e