### PR TITLE
Ensure folder watcher runs only when executed directly

### DIFF
--- a/auto_folder_manager.py
+++ b/auto_folder_manager.py
@@ -127,14 +127,14 @@ if __name__ == "__main__":
     print("📦 Klasörler ve dosyalar hazırlandı.")
 
     observer = Observer()
-observer.schedule(NewFileHandler(), path=".", recursive=True)
-observer.start()
-print("👁 İzleme başlatıldı...")
-try:
-    while True:
-        time.sleep(1)
-except KeyboardInterrupt:
-    observer.stop()
-    print("🛑 İzleme durdu.")
-observer.join()
+    observer.schedule(NewFileHandler(), path=".", recursive=True)
+    observer.start()
+    print("👁 İzleme başlatıldı...")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+        print("🛑 İzleme durdu.")
+    observer.join()
 


### PR DESCRIPTION
## Summary
- Move observer scheduling and loop inside `if __name__ == "__main__"` to avoid running on import

## Testing
- `python - <<'PY'
import auto_folder_manager
print('import ok')
PY` *(fails: ModuleNotFoundError: No module named 'watchdog')*
- `pip install watchdog` *(fails: Could not find a version that satisfies the requirement watchdog)*

------
https://chatgpt.com/codex/tasks/task_e_68967cd053a48321b5c2c7ace3b8c4a7