### PR TITLE
Parameterize UI generation output paths

### DIFF
--- a/agent_loop.py
+++ b/agent_loop.py
@@ -95,7 +95,7 @@ def update_design_based_on_feedback():
     else:
         # sadece refresh
         if os.path.exists(DESIGN_FILE):
-            generate_ui_from_design(DESIGN_FILE)
+            generate_ui_from_design(design_file_path=DESIGN_FILE)
             print("🔄 Mevcut tasarımdan UI yeniden üretildi.")
 
 def agent_loop():

--- a/ai_dashboard/create_design.py
+++ b/ai_dashboard/create_design.py
@@ -87,7 +87,7 @@ def create_design_json():
     print(f"Yeni tasarım dosyası: {file_path}")
 
     # HTML/CSS üret
-    generate_ui_from_design(file_path)
+    generate_ui_from_design(design_file_path=file_path)
 
 if __name__ == "__main__":
     create_design_json()

--- a/auto_folder_manager.py
+++ b/auto_folder_manager.py
@@ -103,7 +103,7 @@ class NewFileHandler(FileSystemEventHandler):
         """design.json dosyasını yakalayıp UI üretir"""
         if file_path.endswith("design.json"):
             print("🎨 Yeni tasarım dosyası algılandı, arayüz oluşturuluyor...")
-            generate_ui_from_design(file_path)
+            generate_ui_from_design(design_file_path=file_path)
 
     def on_created(self, event):
         if not event.is_directory:

--- a/generate_ui.py
+++ b/generate_ui.py
@@ -14,23 +14,17 @@ def get_latest_design_file():
         return "data/design.json"
     raise FileNotFoundError("Hiçbir tasarım dosyası bulunamadı.")
 
-def generate_ui_from_design(*args, **kwargs):
-    if args and isinstance(args[0], str):
-        design_file = args[0]
-    else:
-        design_file = kwargs.get("design_file_path")
-
-    if not design_file:
-        design_file = get_latest_design_file()
+def generate_ui_from_design(design_file_path=None, output_html_path="templates/generated_ui.html", output_css_path="static/css/generated_ui.css"):
+    design_file = design_file_path or get_latest_design_file()
 
     with open(design_file, "r", encoding="utf-8") as f:
         design = json.load(f)
 
-    os.makedirs("templates", exist_ok=True)
-    os.makedirs("static/css", exist_ok=True)
+    os.makedirs(os.path.dirname(output_html_path), exist_ok=True)
+    os.makedirs(os.path.dirname(output_css_path), exist_ok=True)
 
-    html_path = "templates/generated_ui.html"
-    css_path = "static/css/generated_ui.css"
+    html_path = output_html_path
+    css_path = output_css_path
 
     # HTML
     css_version = int(time.time())


### PR DESCRIPTION
## Summary
- allow generate_ui_from_design to accept optional output paths
- route generated files through provided output paths
- update call sites to pass design_file_path explicitly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68967dea573483219d03cc3ba49fe788