### PR TITLE
Add transformers and watchdog dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ pydantic_core==2.33.2
 sniffio==1.3.1
 tornado==6.5.1
 tqdm==4.67.1
+transformers==4.42.0
 typing-inspection==0.4.1
 typing_extensions==4.14.1
+watchdog==4.0.1
 Werkzeug==3.1.3


### PR DESCRIPTION
## Summary
- include transformers 4.42.0 and watchdog 4.0.1 in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0 due to proxy 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68967fff25648321b0044545e29ba1da