### PR TITLE
Redirect root to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def inject_theme():
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return redirect(url_for("dashboard"))
 
 @app.route('/change_theme/<theme_name>')
 def change_theme(theme_name):


### PR DESCRIPTION
## Summary
- Redirect `/` route to the dashboard instead of rendering index template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689687e911a883219d19ac35b693ea14