### PR TITLE
Add theme dashboards with static assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ def set_theme():
 # Dinamik template loader
 @app.context_processor
 def inject_theme():
-    return dict(theme=g.theme_config)
+    return dict(theme=g.theme)
 
 @app.route("/")
 def index():

--- a/static/themes/admin/css/main.css
+++ b/static/themes/admin/css/main.css
@@ -1,0 +1,3 @@
+body.theme-admin {
+    background-color: #f0f0f0;
+}

--- a/static/themes/admin/js/main.js
+++ b/static/themes/admin/js/main.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log('Admin theme loaded');
+});

--- a/static/themes/dark/css/main.css
+++ b/static/themes/dark/css/main.css
@@ -1,0 +1,4 @@
+body.theme-dark {
+    background-color: #121212;
+    color: #ffffff;
+}

--- a/static/themes/dark/js/main.js
+++ b/static/themes/dark/js/main.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    console.log('Dark theme loaded');
+});

--- a/templates/themes/admin/dashboard.html
+++ b/templates/themes/admin/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'themes/base.html' %}
+{% block title %}Admin Dashboard{% endblock %}
+{% block content %}
+<h1>Admin Theme Dashboard</h1>
+<p>Welcome to the admin-themed dashboard.</p>
+{% endblock %}

--- a/templates/themes/base.html
+++ b/templates/themes/base.html
@@ -2,9 +2,9 @@
 <html lang="tr">
   <head>
     <meta charset="UTF-8" />
-    <title>{% block title %}{% endblock %} | {{ theme.name }}</title>
+    <title>{% block title %}{% endblock %} | {{ theme|capitalize }}</title>
     <link
-      href="{{ url_for('static', filename='themes/'+theme+'/css/main.css') }}"
+      href="{{ url_for('static', filename='themes/' + theme + '/css/main.css') }}"
       rel="stylesheet"
     />
     {% block head %}{% endblock %}
@@ -16,6 +16,6 @@
       <div class="content-area">{% block content %}{% endblock %}</div>
     </div>
 
-    <script src="{{ url_for('static', filename='themes/'+theme+'/js/main.js') }}"></script>
+    <script src="{{ url_for('static', filename='themes/' + theme + '/js/main.js') }}"></script>
   </body>
 </html>

--- a/templates/themes/dark/dashboard.html
+++ b/templates/themes/dark/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'themes/base.html' %}
+{% block title %}Dark Dashboard{% endblock %}
+{% block content %}
+<h1>Dark Theme Dashboard</h1>
+<p>Welcome to the dark-themed dashboard.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin and dark dashboard templates extending base theme
- include theme-specific CSS and JS assets
- fix theme context and base template to load static resources

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68968992d5bc8321889fb03c9687cd79